### PR TITLE
Track Active Tab

### DIFF
--- a/WikidPad.xrc
+++ b/WikidPad.xrc
@@ -5427,6 +5427,12 @@
       <label>Copy WikiWord to clipboard</label>
       <help>Copy the name for current page to the clipboard</help>
     </object>
+    <object class="wxMenuItem" name="CMD_TRACK_ACTIVE_TAB">
+      <label>Track active tab</label>
+      <help>When the active tab change word or cursor location so does this tab</help>
+      <checkable>1</checkable>
+      <checked>0</checked>
+    </object>
   </object>
   <object class="wxMenu" name="MenuSearchResultTabPopup">
     <object class="wxMenuItem" name="CMD_CLOSE_THIS_TAB">

--- a/lib/pwiki/MainAreaPanel.py
+++ b/lib/pwiki/MainAreaPanel.py
@@ -106,6 +106,8 @@ class MainAreaPanel(aui.AuiNotebook, MiscEventSourceMixin, StorablePerspective):
                 self.OnCmdClipboardCopyUrlToThisWikiWord)
         wx.EVT_MENU(self, GUI_ID.CMD_CLIPBOARD_COPY_WIKIWORD,
                 self.OnCmdClipboardCopyWikiWord)
+        wx.EVT_MENU(self, GUI_ID.CMD_TRACK_ACTIVE_TAB,
+                self.OnCmdTrackActiveTab)
 
     def close(self):
         for p in self.getPresenters():
@@ -768,6 +770,13 @@ class MainAreaPanel(aui.AuiNotebook, MiscEventSourceMixin, StorablePerspective):
         copyTextToClipboard(wikiWord)
 
 
+    def OnCmdTrackActiveTab(self, evt):
+        if not isinstance(self.lastContextMenuPresenter, BasicDocPagePresenter):
+            return
+
+        self.lastContextMenuPresenter.setTrackActiveTab(evt.IsChecked())
+
+
     def OnTabMiddleDown(self, evt):
         #tab = evt.GetSelection()
         #if tab == wx.NOT_FOUND:
@@ -786,6 +795,8 @@ class MainAreaPanel(aui.AuiNotebook, MiscEventSourceMixin, StorablePerspective):
 
 
     def miscEventHappened(self, miscevt):
+        if not miscevt.has_key("idle visible"):
+            pass # potential break point here (avoids breaking on spam)
         idx = self.GetPageIndex(miscevt.getSource())
         if idx != wx.NOT_FOUND:
             if miscevt.has_key("changed presenter title"):
@@ -800,6 +811,9 @@ class MainAreaPanel(aui.AuiNotebook, MiscEventSourceMixin, StorablePerspective):
             if miscevt.has_key("closed current wiki"):
                 # self._closeAllButCurrentTab()
                 self._closeAllTabs()
+
+        if miscevt.getSource() is self.getCurrentPresenter() and not miscevt.has_key("presenter forward"):
+            self.fireMiscEventProps({"forward from current presenter": miscevt.getProps()})
 
 
 # ----- Implementation of StorablePerspective methods -----

--- a/lib/pwiki/MiscEvent.py
+++ b/lib/pwiki/MiscEvent.py
@@ -432,6 +432,10 @@ class MiscEvent(object):
         """
         event = self.createClone(shareListenerList=shareListenerList)
         event.properties.update(addprops)
+        if event.properties.has_key("original sources"):
+            event.properties["original sources"] = event.properties["original sources"] + [self.source]
+        else:
+            event.properties["original sources"] = [self.source]
         return event
 
     def createCloneAddKeys(self, addkeys, shareListenerList=False):
@@ -442,6 +446,7 @@ class MiscEvent(object):
         @param addkeys  Sequence with additional keys for properties
         """
         event = self.createClone(shareListenerList=shareListenerList)
+        event.properties["original sources"] = [self.source]
         for k in addkeys:
             event.properties[k] = True
         return event


### PR DESCRIPTION
Editor and preview tab context menu contain option to enable/disable
"track active tab". If enabled then when the active tab change WikiWord
or another tabs become the active one then this tab will also change to
the new WikiWord. (Usually I have the tracking tab in preview mode and
in bottom half of screen, and other tabs in edit mode and in top half of
screen)